### PR TITLE
Trading agreement fix for Germans

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ KRAKEN_BUY_AMOUNT=21 # fiat amount you trade for the future of money
 KRAKEN_MAX_REL_FEE=0.5 # maximum fee in % that you are willing to pay
 KRAKEN_WITHDRAW_KEY="descriptionOfWithdrawalAddress"
 
+# set this if you live in Germany and get the 'EOrder:Trading agreement required' error
+# see https://support.kraken.com/hc/en-us/articles/360000920026--Trading-agreement-required-error-for-German-residents
+KRAKEN_GERMANY_TRADING_AGREEMENT="agree"
+
 # remove this line after verifying everything works
 KRAKEN_DRY_RUN_PLACE_NO_ORDER=1
 ```

--- a/commands/stack.js
+++ b/commands/stack.js
@@ -1,6 +1,10 @@
 module.exports = async (kraken, validate, { getEnv, getEnvOpt }) => {
   const [fiat, amount] = getEnv('KRAKEN_API_FIAT', 'KRAKEN_BUY_AMOUNT')
   const ordertype = getEnvOpt('KRAKEN_ORDER_TYPE', 'limit', ['limit', 'market'])
+  // if living in Germany, one needs to add an additional parameter to explicitly agree to the trade
+  // if the parameter is not set one will get the following error: EOrder:Trading agreement required
+  // see https://support.kraken.com/hc/en-us/articles/360000920026--Trading-agreement-required-error-for-German-residents
+  const trading_agreement = getEnvOpt('KRAKEN_GERMANY_TRADING_AGREEMENT', '', ['agree', ''])
 
   // https://www.kraken.com/features/api
   const crypto = 'XBT'
@@ -27,6 +31,7 @@ module.exports = async (kraken, validate, { getEnv, getEnvOpt }) => {
   // Place order
   const details = { pair, type: 'buy', ordertype, price, volume }
   if (validate) details.validate = true
+  if (trading_agreement) details.trading_agreement = trading_agreement
 
   const { result: { descr: { order }, txid } } = await kraken.api('AddOrder', details)
 


### PR DESCRIPTION
As a German trying to place an order via the API you will get an
exception: 'EOrder:Trading agreement required'.
You have to set the 'trading_agreement' parameter to 'agree' (see
https://support.kraken.com/hc/en-us/articles/360000920026--Trading-agreement-required-error-for-German-residents).