### PR TITLE
Set Fee currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ KRAKEN_API_SECRET="privateKeyFromTheKrakenSettings"
 KRAKEN_ORDER_TYPE="market" # "limit" (default) or "market"
 KRAKEN_API_FIAT="USD" # the governmental shitcoin you are selling
 KRAKEN_BUY_AMOUNT=21 # fiat amount you trade for the future of money
+KRAKEN_FEE_CURRENCY="XBT" # pay fee in this currency, e.g. buying XBT for USD and paying fee in XBT
 
 # used for withdrawal
 KRAKEN_MAX_REL_FEE=0.5 # maximum fee in % that you are willing to pay


### PR DESCRIPTION
Fees are by default paid with the fiat money. This means that you bought
crypto for the specified amount (e.g. 25 USD) and the fees are charged
separately. When you want to spend 100 USD over 4 weeks, meaning 1 order
per week, the last order won't be placed since there is not enough fiat
money left.
In my case I wanted to spend 100 EUR a month, meaning 25 € once per
week. When testing it the first time I was charged 25,065 EUR. By
setting the fee to XBT instead of EUR, I can run the script 4 times a
month.