### PR TITLE
Price ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ PATH=/bin:/usr/sbin:/usr/bin:/usr/local/bin
 
 **Note:** Do not run `npm` directly on the RaspiBlitz, like show in the examples below.
 Please use the `/home/stackingsats/stacking-sats-kraken/stacksats.sh` shell script instead, as this loads your configuration.
+On RaspiBlitz (v1.8 and above) you may use different configuration files for e.g. family or business.
 
 To run the script manually, switch to the `stackingsats` user and use this command:
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ KRAKEN_ORDER_TYPE="market" # "limit" (default) or "market"
 KRAKEN_API_FIAT="USD" # the governmental shitcoin you are selling
 KRAKEN_BUY_AMOUNT=21 # fiat amount you trade for the future of money
 KRAKEN_FEE_CURRENCY="XBT" # pay fee in this currency, e.g. buying XBT for USD and paying fee in XBT
+#KRAKEN_BUY_RATIO=0.99 # place order at 99% of current bid price, e.g. to ensure maker fees
 
 # used for withdrawal
 KRAKEN_MAX_REL_FEE=0.5 # maximum fee in % that you are willing to pay

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ export KRAKEN_BUY_AMOUNT=21
 export KRAKEN_MAX_REL_FEE=0.5
 export KRAKEN_WITHDRAW_KEY="descriptionOfWithdrawalAddress"
 export KRAKEN_DRY_RUN_PLACE_NO_ORDER=1
+export KRAKEN_BUY_RATIO=0.99
 
 # run script
 cd $(cd `dirname $0` && pwd)

--- a/commands/stack.js
+++ b/commands/stack.js
@@ -1,5 +1,6 @@
 module.exports = async (kraken, validate, { getEnv, getEnvOpt }) => {
   const [fiat, amount, feeCurrency] = getEnv('KRAKEN_API_FIAT', 'KRAKEN_BUY_AMOUNT', 'KRAKEN_FEE_CURRENCY')
+  const ratio = getEnvOpt('KRAKEN_BUY_RATIO', '1.0')
   const ordertype = getEnvOpt('KRAKEN_ORDER_TYPE', 'limit', ['limit', 'market'])
   // if living in Germany, one needs to add an additional parameter to explicitly agree to the trade
   // if the parameter is not set one will get the following error: EOrder:Trading agreement required
@@ -29,14 +30,16 @@ module.exports = async (kraken, validate, { getEnv, getEnvOpt }) => {
   const [{ a: [a], b: [b] }] = Object.values(ticker)
   const ask = parseFloat(a)
   const bid = parseFloat(b)
-  const price = bid
+  const price = Math.round( bid * ratio * 10 ) / 10
 
   // Calculate volume and adjust precision
   const volume = (amount / price).toFixed(8)
 
   console.log('💰  Balance:', fiatBalance, fiat, '/', cryptoBalance, crypto, '\n')
   console.log('📈  Ask:', ask, fiat)
-  console.log('📉  Bid:', bid, fiat, '\n')
+  console.log('📉  Bid:', bid, fiat, '(', ( ratio * 100 ), '%', ')')
+  console.log('🏷️  Price:', price, fiat, "/", "XBT")
+  console.log('\n')
 
   if (parseFloat(fiatBalance) < parseFloat(amount)) {
     console.log('❌  Insufficient funds')


### PR DESCRIPTION
I did this locally on raspiblitz a while back to have more control over fees. So now I want to push it upstream as I like to have less patches flying around and it might be a good idea for others as well. Default is still `1.0`, so no changes to anyone who doesn't want them.

alternatives:
* drop the idea
* changing referenced repository on raspiblitz / include the files instead of a reference
